### PR TITLE
Fix createSyncView unmounting modules ...

### DIFF
--- a/src/modules/bootstrap/higherOrderComponents/createSyncView.js
+++ b/src/modules/bootstrap/higherOrderComponents/createSyncView.js
@@ -4,24 +4,37 @@ import createLog from 'utilities/log'
 
 export default function createSyncView({ modules = [], name, view, Wrapper }) {
   const log = createLog(`modules:bootstrap:createSyncView:${name}`)
-
+  let mounting = false
   const contextTypes = {
     store: PropTypes.object,
   }
 
   class SyncLoader extends Component {
     componentWillMount() {
+      mounting = true
       log.mount('Start')
       const { store } = this.context
       store.registerModules([view, ...modules])
       log.mount('Done')
     }
 
+    componentDidMount() {
+      mounting = false
+    }
+
     componentWillUnmount() {
-      log.unmount('Start')
-      const { store } = this.context
-      store.unregisterModules([view, ...modules])
-      log.unmount('Done')
+      /*
+      * If the same component is remounted componentWillUnmount
+      * of the old component will be called after componentWillMount
+      * for the new component and because of that this check is needed
+      * to not immediately remove the newly mounted component
+      */
+      if (!mounting) {
+        log.unmount('Start')
+        const { store } = this.context
+        store.unregisterModules([view, ...modules])
+        log.unmount('Done')
+      }
     }
 
     render() {


### PR DESCRIPTION
... when the same component is reloaded. This assumes that a component calling componentWillMount will get mount before it should be removed. If not the module will hang around.  If this becomes and issue another approach should be used.